### PR TITLE
Fixed user avatar URL

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -53,7 +53,7 @@ class Provider extends AbstractProvider implements ProviderInterface
             'id'     => $user['id'], 'nickname' => null,
             'name'   => Arr::get($user, 'firstName').' '.Arr::get($user, 'lastName'),
             'email'  => $user['contact']['email'],
-            'avatar' => $user['photo']['prefix'].$user['photo']['suffix'],
+            'avatar' => $user['photo']['prefix'].'original'.$user['photo']['suffix'],
         ]);
     }
 


### PR DESCRIPTION
Foursquare's API needs a size when requesting the user's profile image. This change sets it to `original`. Without this, the avatar URL leads to a 404.
https://developer.foursquare.com/docs/api/photos/details